### PR TITLE
Update README to reflect third party caveat fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,18 +319,6 @@ new MacaroonsVerifier(m)
 
 Without the 'prepare_for_request()' call, the verification would fail.
 
-Interestingly, when you're verifying a macaroon without satisfy3rdParty(),
-then the verification process will proceed and ignore them. 
- 
-````java
-new MacaroonsVerifier(m)
-    .satisfyExcact("account = 3735928559")
-    .satisfyGeneral(new TimestampCaveatVerifier())
-    /* don't verify 3rd party caveat - will be valid, too */
-    .assertIsValid(secret);
-// > ok.
-````
-
 
 Commonly used verifier, shipped with jmacaroons
 --------------------------------------------------


### PR DESCRIPTION
Strip out comment in readme stating that third party caveat verfication
is optional (discussed in #1, fixed by a0f276f6).
