### PR TITLE
Fix spelling mistake satisfyExcact -> satisfyExact

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ verifier.isValid(secretKey);
 Caveats like these are called "exact caveats" because there is exactly one way
 to satisfy them.  Either the account number is 3735928559, or it isn't.  At
 verification time, the verifier will check each caveat in the macaroon against
-the list of satisfied caveats provided to "satisfyExcact()".  When it finds a
+the list of satisfied caveats provided to "satisfyExact()".  When it finds a
 match, it knows that the caveat holds and it can move onto the next caveat in
 the macaroon.
 ````java
-verifier.satisfyExcact("account = 3735928559");
+verifier.satisfyExact("account = 3735928559");
 verifier.isValid(secretKey);
 // > True
 ````
@@ -191,8 +191,8 @@ policy changes; for example, by adding the three following facts,
 the verifier will continue to work even if someone decides to
 self-attenuate itself macaroons to be only usable from IP address and browser:
 ````java
-verifier.satisfyExcact("IP = 127.0.0.1')");
-verifier.satisfyExcact("browser = Chrome')");
+verifier.satisfyExact("IP = 127.0.0.1')");
+verifier.satisfyExact("browser = Chrome')");
 verifier.isValid(secretKey);
 // > True
 ````
@@ -311,7 +311,7 @@ argument to the verify call:
 
 ````java
 new MacaroonsVerifier(m)
-    .satisfyExcact("account = 3735928559")
+    .satisfyExact("account = 3735928559")
     .satisfyGeneral(new TimestampCaveatVerifier())
     .satisfy3rdParty(dp)
     .assertIsValid(secret);

--- a/src/example/java/com/github/nitram509/jmacaroons/examples/MacaroonsExamples.java
+++ b/src/example/java/com/github/nitram509/jmacaroons/examples/MacaroonsExamples.java
@@ -95,13 +95,13 @@ public class MacaroonsExamples {
     verifier.isValid(secretKey);
     // > False
 
-    verifier.satisfyExcact("account = 3735928559");
+    verifier.satisfyExact("account = 3735928559");
     verifier.isValid(secretKey);
     // > True
 
-    verifier.satisfyExcact("IP = 127.0.0.1')");
-    verifier.satisfyExcact("browser = Chrome')");
-    verifier.satisfyExcact("action = deposit");
+    verifier.satisfyExact("IP = 127.0.0.1')");
+    verifier.satisfyExact("browser = Chrome')");
+    verifier.satisfyExact("action = deposit");
     verifier.isValid(secretKey);
     // > True
   }
@@ -155,7 +155,7 @@ public class MacaroonsExamples {
     System.out.println("dp.signature = " + dp.signature);
 
     new MacaroonsVerifier(m)
-        .satisfyExcact("account = 3735928559")
+        .satisfyExact("account = 3735928559")
         .satisfyGeneral(new TimestampCaveatVerifier())
         .satisfy3rdParty(dp)
         .assertIsValid(secret);

--- a/src/main/java/com/github/nitram509/jmacaroons/MacaroonsVerifier.java
+++ b/src/main/java/com/github/nitram509/jmacaroons/MacaroonsVerifier.java
@@ -200,14 +200,14 @@ public class MacaroonsVerifier {
    * Caveats like these are called "exact caveats" because there is exactly one way
    * to satisfy them.  Either the given caveat matches, or it doesn't.  At
    * verification time, the verifier will check each caveat in the macaroon against
-   * the list of satisfied caveats provided to satisfyExcact(String).
+   * the list of satisfied caveats provided to satisfyExact(String).
    * When it finds a match, it knows that the caveat holds and it can move onto the next caveat in
    * the macaroon.
    *
    * @param caveat caveat
    * @return this {@link com.github.nitram509.jmacaroons.MacaroonsVerifier}
    */
-  public MacaroonsVerifier satisfyExcact(String caveat) {
+  public MacaroonsVerifier satisfyExact(String caveat) {
     if (caveat != null) {
       this.predicates = appendToArray(this.predicates, caveat);
     }

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsPrepareRequestAndVerifyComplexTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsPrepareRequestAndVerifyComplexTest.java
@@ -74,8 +74,8 @@ public class MacaroonsPrepareRequestAndVerifyComplexTest {
   @Test(dependsOnMethods = "preparing_a_macaroon_for_request")
   public void verifying_valid() {
     boolean valid = new MacaroonsVerifier(M)
-        .satisfyExcact("account = 3735928559")
-        .satisfyExcact("role = admin")
+        .satisfyExact("account = 3735928559")
+        .satisfyExact("role = admin")
         .satisfyGeneral(new TimestampCaveatVerifier())
         .satisfy3rdParty(DP)
         .isValid(secret);
@@ -86,8 +86,8 @@ public class MacaroonsPrepareRequestAndVerifyComplexTest {
   @Test(dependsOnMethods = "preparing_a_macaroon_for_request")
   public void verifying_unprepared_macaroon__has_to_fail() {
     boolean valid = new MacaroonsVerifier(M)
-        .satisfyExcact("account = 3735928559")
-        .satisfyExcact("role = admin")
+        .satisfyExact("account = 3735928559")
+        .satisfyExact("role = admin")
         .satisfyGeneral(new TimestampCaveatVerifier())
         .satisfy3rdParty(D)
         .isValid(secret);
@@ -98,8 +98,8 @@ public class MacaroonsPrepareRequestAndVerifyComplexTest {
   @Test(dependsOnMethods = "preparing_a_macaroon_for_request")
   public void verifying_macaroon_without_satisfying_3rd_party__has_to_fail() {
     boolean valid = new MacaroonsVerifier(M)
-        .satisfyExcact("account = 3735928559")
-        .satisfyExcact("role = admin")
+        .satisfyExact("account = 3735928559")
+        .satisfyExact("role = admin")
         .satisfyGeneral(new TimestampCaveatVerifier())
         .isValid(secret);
 

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsPrepareRequestAndVerifyTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsPrepareRequestAndVerifyTest.java
@@ -77,7 +77,7 @@ public class MacaroonsPrepareRequestAndVerifyTest {
   @Test(dependsOnMethods = "preparing_a_macaroon_for_request")
   public void verifying_valid() {
     boolean valid = new MacaroonsVerifier(M)
-        .satisfyExcact("account = 3735928559")
+        .satisfyExact("account = 3735928559")
         .satisfyGeneral(new TimestampCaveatVerifier())
         .satisfy3rdParty(DP)
         .isValid(secret);
@@ -88,7 +88,7 @@ public class MacaroonsPrepareRequestAndVerifyTest {
   @Test(dependsOnMethods = "preparing_a_macaroon_for_request")
   public void verifying_unprepared_macaroon__has_to_fail() {
     boolean valid = new MacaroonsVerifier(M)
-        .satisfyExcact("account = 3735928559")
+        .satisfyExact("account = 3735928559")
         .satisfyGeneral(new TimestampCaveatVerifier())
         .satisfy3rdParty(D)
         .isValid(secret);
@@ -99,7 +99,7 @@ public class MacaroonsPrepareRequestAndVerifyTest {
   @Test(dependsOnMethods = "preparing_a_macaroon_for_request")
   public void verifying_macaroon_without_satisfying_3rd_party__has_to_fail() {
     boolean valid = new MacaroonsVerifier(M)
-        .satisfyExcact("account = 3735928559")
+        .satisfyExact("account = 3735928559")
         .satisfyGeneral(new TimestampCaveatVerifier())
         .isValid(secret);
 

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsVerifierTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsVerifierTest.java
@@ -79,7 +79,7 @@ public class MacaroonsVerifierTest {
     MacaroonsVerifier verifier = new MacaroonsVerifier(m);
     assertThat(verifier.isValid(secret)).isFalse();
 
-    verifier.satisfyExcact("account = 3735928559");
+    verifier.satisfyExact("account = 3735928559");
     assertThat(verifier.isValid(secret)).isTrue();
   }
 
@@ -93,7 +93,7 @@ public class MacaroonsVerifierTest {
     MacaroonsVerifier verifier = new MacaroonsVerifier(m);
     assertThat(verifier.isValid(secret)).isFalse();
 
-    verifier.satisfyExcact("account = 3735928559");
+    verifier.satisfyExact("account = 3735928559");
     assertThat(verifier.isValid(secret)).isFalse();
   }
 
@@ -106,10 +106,10 @@ public class MacaroonsVerifierTest {
     MacaroonsVerifier verifier = new MacaroonsVerifier(m);
     assertThat(verifier.isValid(secret)).isFalse();
 
-    verifier.satisfyExcact("account = 3735928559");
-    verifier.satisfyExcact("IP = 127.0.0.1')");
-    verifier.satisfyExcact("browser = Chrome')");
-    verifier.satisfyExcact("action = deposit");
+    verifier.satisfyExact("account = 3735928559");
+    verifier.satisfyExact("IP = 127.0.0.1')");
+    verifier.satisfyExact("browser = Chrome')");
+    verifier.satisfyExact("action = deposit");
     assertThat(verifier.isValid(secret)).isTrue();
   }
 


### PR DESCRIPTION
Super minor, but very jarring. I understand that this is changing the name of a method, semver and all that, but it looks _bad_. This patch will probably survive a lot going on without needing to be reworked, so if you hold off applying it I won't be offended.
