### PR TITLE
Changed key handling to consistently ensure we always derive a fixed-…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk7
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 after_success:
   - mvn clean cobertura:cobertura coveralls:cobertura

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/src/main/java/com/github/nitram509/jmacaroons/CryptoTools.java
+++ b/src/main/java/com/github/nitram509/jmacaroons/CryptoTools.java
@@ -48,8 +48,18 @@ class CryptoTools {
     return macaroon_hmac(MACAROONS_MAGIC_KEY.getBytes(IDENTIFIER_CHARSET), variableKey);
   }
 
+  static byte[] generate_derived_key(byte[] variableKey) throws InvalidKeyException, NoSuchAlgorithmException {
+    return macaroon_hmac(MACAROONS_MAGIC_KEY.getBytes(IDENTIFIER_CHARSET), variableKey);
+  }
+
   static byte[] macaroon_hmac(byte[] key, String message) throws NoSuchAlgorithmException, InvalidKeyException {
-    return macaroon_hmac(key, message.getBytes(IDENTIFIER_CHARSET));
+    return macaroon_hmac(key, string_to_bytes(message));
+  }
+
+  static byte[] string_to_bytes(String message) {
+    return message == null
+        ? null
+        : message.getBytes(STRING_KEY_CHARSET);
   }
 
   static byte[] macaroon_hmac(byte[] key, byte[] message) throws NoSuchAlgorithmException, InvalidKeyException {

--- a/src/main/java/com/github/nitram509/jmacaroons/MacaroonsBuilder.java
+++ b/src/main/java/com/github/nitram509/jmacaroons/MacaroonsBuilder.java
@@ -22,6 +22,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
 import static com.github.nitram509.jmacaroons.CryptoTools.*;
+import static com.github.nitram509.jmacaroons.MacaroonsConstants.IDENTIFIER_CHARSET;
 import static com.github.nitram509.jmacaroons.MacaroonsConstants.MACAROON_MAX_CAVEATS;
 import static com.github.nitram509.jmacaroons.MacaroonsConstants.MACAROON_MAX_STRLEN;
 
@@ -45,7 +46,7 @@ public class MacaroonsBuilder {
    * @throws com.github.nitram509.jmacaroons.GeneralSecurityRuntimeException
    */
   public MacaroonsBuilder(String location, String secretKey, String identifier) throws GeneralSecurityRuntimeException {
-    this.macaroon = computeMacaroon(location, secretKey, identifier);
+    this.macaroon = computeMacaroon(location, string_to_bytes(secretKey), identifier);
   }
 
   /**
@@ -73,7 +74,7 @@ public class MacaroonsBuilder {
    * @return {@link com.github.nitram509.jmacaroons.Macaroon}
    */
   public static Macaroon create(String location, String secretKey, String identifier) {
-    return computeMacaroon(location, secretKey, identifier);
+    return computeMacaroon(location, string_to_bytes(secretKey), identifier);
   }
 
   /**
@@ -181,19 +182,12 @@ public class MacaroonsBuilder {
     }
   }
 
-  private static Macaroon computeMacaroon(String location, String secretKey, String identifier) throws GeneralSecurityRuntimeException {
-    try {
-      return computeMacaroon(location, generate_derived_key(secretKey), identifier);
-    } catch (InvalidKeyException | NoSuchAlgorithmException e) {
-      throw new GeneralSecurityRuntimeException(e);
-    }
-  }
-
   private static Macaroon computeMacaroon(String location, byte[] secretKey, String identifier) throws GeneralSecurityRuntimeException {
     assert location.length() < MACAROON_MAX_STRLEN;
     assert identifier.length() < MACAROON_MAX_STRLEN;
     try {
-      byte[] hash = macaroon_hmac(secretKey, identifier);
+      byte[] derived_key = generate_derived_key(secretKey);
+      byte[] hash = macaroon_hmac(derived_key, identifier);
       return new Macaroon(location, identifier, hash);
     } catch (InvalidKeyException | NoSuchAlgorithmException e) {
       throw new GeneralSecurityRuntimeException(e);

--- a/src/main/java/com/github/nitram509/jmacaroons/MacaroonsConstants.java
+++ b/src/main/java/com/github/nitram509/jmacaroons/MacaroonsConstants.java
@@ -86,4 +86,7 @@ public interface MacaroonsConstants {
   int KEY_VALUE_SEPARATOR_LEN = 1;
 
   Charset IDENTIFIER_CHARSET = Charset.forName("UTF-8");
+
+  // for maximal compatibility between strings and byte arrays for keys, use an encoding that is reversible
+  Charset STRING_KEY_CHARSET = Charset.forName("ISO-8859-1");
 }

--- a/src/main/java/com/github/nitram509/jmacaroons/MacaroonsVerifier.java
+++ b/src/main/java/com/github/nitram509/jmacaroons/MacaroonsVerifier.java
@@ -45,11 +45,7 @@ public class MacaroonsVerifier {
    * @throws com.github.nitram509.jmacaroons.GeneralSecurityRuntimeException when the runtime doesn't provide sufficient crypto support
    */
   public void assertIsValid(String secret) throws MacaroonValidationException, GeneralSecurityRuntimeException {
-    try {
-      assertIsValid(generate_derived_key(secret));
-    } catch (InvalidKeyException | NoSuchAlgorithmException e) {
-      throw new GeneralSecurityRuntimeException(e);
-    }
+    assertIsValid(string_to_bytes(secret));
   }
 
   /**
@@ -59,7 +55,7 @@ public class MacaroonsVerifier {
    */
   public void assertIsValid(byte[] secret) throws MacaroonValidationException, GeneralSecurityRuntimeException {
     try {
-      VerificationResult result = isValid_verify_raw(macaroon, secret);
+      VerificationResult result = isValid_verify_raw(macaroon, generate_derived_key(secret));
       if (result.fail) {
         String msg = result.failMessage != null ? result.failMessage : "This macaroon isn't valid.";
         throw new MacaroonValidationException(msg, macaroon);
@@ -75,11 +71,7 @@ public class MacaroonsVerifier {
    * @throws com.github.nitram509.jmacaroons.GeneralSecurityRuntimeException
    */
   public boolean isValid(String secret) throws GeneralSecurityRuntimeException {
-    try {
-      return isValid(generate_derived_key(secret));
-    } catch (InvalidKeyException | NoSuchAlgorithmException e) {
-      throw new GeneralSecurityRuntimeException(e);
-    }
+    return isValid(string_to_bytes(secret));
   }
 
   /**
@@ -89,7 +81,7 @@ public class MacaroonsVerifier {
    */
   public boolean isValid(byte[] secret) throws GeneralSecurityRuntimeException {
     try {
-      return !isValid_verify_raw(macaroon, secret).fail;
+      return !isValid_verify_raw(macaroon, generate_derived_key(secret)).fail;
     } catch (InvalidKeyException | NoSuchAlgorithmException e) {
       throw new GeneralSecurityRuntimeException(e);
     }

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsBuilderTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsBuilderTest.java
@@ -91,7 +91,7 @@ public class MacaroonsBuilderTest {
 
     m = MacaroonsBuilder.create(location, secretBytes, identifier);
 
-    assertThat(m.signature).isEqualTo("5c748a4dabfd5ff2a0b5ab56120c8021912b591ac09023b4bffbc6e1b54e664f");
+    assertThat(m.signature).isEqualTo("e3d9e02908526c4c0039ae15114115d97fdd68bf2ba379b342aaf0f617d0552f");
   }
 
 }

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsPrepareRequestAndVerifyTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsPrepareRequestAndVerifyTest.java
@@ -22,6 +22,10 @@ import org.testng.annotations.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+import java.nio.charset.Charset;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
 public class MacaroonsPrepareRequestAndVerifyTest {
 
   private String identifier;
@@ -104,5 +108,61 @@ public class MacaroonsPrepareRequestAndVerifyTest {
         .isValid(secret);
 
     assertThat(valid).isFalse();
+  }
+
+
+  @Test
+  public void using_non_string_key_bytes_for_3rd_party__should_succeed() {
+
+    byte[] root_key = keyGen();
+    byte[] caveat_key = keyGen();
+    String caveat_id = "caveat";
+    String macaroon_id = "123456";
+    Macaroon M = new MacaroonsBuilder("some-service", root_key, macaroon_id)
+        .add_third_party_caveat("authN", new String(caveat_key, Charset.forName("ISO-8859-1")), caveat_id)
+        .getMacaroon();
+
+    assertThat(new MacaroonsVerifier(M)
+        .isValid(root_key))
+        .describedAs("Original should not be valid without discharge macaroon")
+        .isFalse();
+
+    // create discharge macaroon using caveat key as bytes
+    Macaroon D = new MacaroonsBuilder("authN", caveat_key, caveat_id)
+        .getMacaroon();
+
+    assertThat(new MacaroonsVerifier(D)
+        .isValid(caveat_key))
+        .describedAs("Discharge macaroon should be valid")
+        .isTrue();
+
+    // prepare discharge macaroon by binding to the original macaroon
+    Macaroon bound = new MacaroonsBuilder(M)
+        .prepare_for_request(D)
+        .getMacaroon();
+
+    assertThat(new MacaroonsVerifier(bound)
+        .isValid(caveat_key))
+        .describedAs("Bound discharge macaroon should not be considered valid on its own")
+        .isFalse();
+
+    assertThat(new MacaroonsVerifier(M)
+        .satisfy3rdParty(bound)
+        .isValid(root_key))
+        .describedAs("Original should be valid with third party caveat bound")
+        .isTrue();
+  }
+
+  byte[] keyGen() {
+    try {
+      byte[] keyBytes = new byte[com.github.nitram509.jmacaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH];
+      SecureRandom prng = SecureRandom.getInstanceStrong();
+      prng.nextBytes(keyBytes);
+      return keyBytes;
+    }
+    catch (NoSuchAlgorithmException e) {
+      e.printStackTrace();
+    }
+    return null;
   }
 }


### PR DESCRIPTION
…length key from that string or bytes, to be consistent with other macaroon implementations.

Ensure that string -> byte conversion is reversible so string keys can be used interchangeably with those same keys as byte arrays without messing up signature validation.

Resolves issue #11 -- but more consistently with other libraries that always derive fixed-length keys no matter what the source key material (string or byte array).  This ensures that signatures are consistently generated no matter the format of the key material.