### PR TITLE
Use a more familiar builder API

### DIFF
--- a/src/example/java/com/github/nitram509/jmacaroons/examples/MacaroonsExamples.java
+++ b/src/example/java/com/github/nitram509/jmacaroons/examples/MacaroonsExamples.java
@@ -38,7 +38,7 @@ public class MacaroonsExamples {
     String location = "http://www.example.org";
     String secretKey = "this is our super secret key; only we should know it";
     String identifier = "we used our secret key";
-    Macaroon macaroon = MacaroonsBuilder.create(location, secretKey, identifier);
+    Macaroon macaroon = Macaroon.create(location, secretKey, identifier);
     System.out.println(macaroon.inspect());
 
     return macaroon;
@@ -54,7 +54,7 @@ public class MacaroonsExamples {
   void deserialize() {
     String serialized = create().serialize();
 
-    Macaroon macaroon = MacaroonsBuilder.deserialize(serialized);
+    Macaroon macaroon = Macaroon.deserialize(serialized);
     System.out.println(macaroon.inspect());
   }
 
@@ -72,17 +72,17 @@ public class MacaroonsExamples {
     String location = "http://www.example.org";
     String secretKey = "this is our super secret key; only we should know it";
     String identifier = "we used our secret key";
-    Macaroon macaroon = new MacaroonsBuilder(location, secretKey, identifier)
-        .add_first_party_caveat("account = 3735928559")
-        .getMacaroon();
+    Macaroon macaroon = Macaroon.builder(location, secretKey, identifier)
+        .addCaveat("account = 3735928559")
+        .build();
     System.out.println(macaroon.inspect());
   }
 
   void addCaveat_modify() throws InvalidKeyException, NoSuchAlgorithmException {
     Macaroon macaroon = create();
-    macaroon = MacaroonsBuilder.modify(macaroon)
-        .add_first_party_caveat("account = 3735928559")
-        .getMacaroon();
+    macaroon = Macaroon.builder(macaroon)
+        .addCaveat("account = 3735928559")
+        .build();
     System.out.println(macaroon.inspect());
   }
 
@@ -90,9 +90,9 @@ public class MacaroonsExamples {
     String location = "http://www.example.org";
     String secretKey = "this is our super secret key; only we should know it";
     String identifier = "we used our secret key";
-    Macaroon macaroon = new MacaroonsBuilder(location, secretKey, identifier)
-        .add_first_party_caveat("account = 3735928559")
-        .getMacaroon();
+    Macaroon macaroon = Macaroon.builder(location, secretKey, identifier)
+        .addCaveat("account = 3735928559")
+        .build();
     MacaroonsVerifier verifier = new MacaroonsVerifier(macaroon);
     verifier.isValid(secretKey);
     // > False
@@ -113,9 +113,9 @@ public class MacaroonsExamples {
     String secretKey = "this is our super secret key; only we should know it";
     String identifier = "we used our secret key";
 
-    Macaroon macaroon = new MacaroonsBuilder(location, secretKey, identifier)
-        .add_first_party_caveat("time < 2042-01-01T00:00")
-        .getMacaroon();
+    Macaroon macaroon = Macaroon.builder(location, secretKey, identifier)
+        .addCaveat("time < 2042-01-01T00:00")
+        .build();
     MacaroonsVerifier verifier = new MacaroonsVerifier(macaroon);
     verifier.isValid(secretKey);
     // > False
@@ -130,8 +130,8 @@ public class MacaroonsExamples {
     String location = "http://mybank/";
     String secret = "this is a different super-secret key; never use the same secret twice";
     String publicIdentifier = "we used our other secret key";
-    MacaroonsBuilder mb = new MacaroonsBuilder(location, secret, publicIdentifier)
-        .add_first_party_caveat("account = 3735928559");
+    MacaroonsBuilder mb = Macaroon.builder(location, secret, publicIdentifier)
+        .addCaveat("account = 3735928559");
 
     // add a 3rd party caveat
     // you'll likely want to use a higher entropy source to generate this key
@@ -140,8 +140,8 @@ public class MacaroonsExamples {
     // send_to_3rd_party_location_and_do_auth(caveat_key, predicate);
     // identifier = recv_from_auth();
     String identifier = "this was how we remind auth of key/pred";
-    Macaroon m = mb.add_third_party_caveat("http://auth.mybank/", caveat_key, identifier)
-        .getMacaroon();
+    Macaroon m = mb.addCaveat("http://auth.mybank/", caveat_key, identifier)
+        .build();
 
     System.out.println(m.inspect());
 
@@ -149,13 +149,13 @@ public class MacaroonsExamples {
         .plus(Duration.ofHours(1))
         .toString();
 
-    Macaroon d = new MacaroonsBuilder("http://auth.mybank/", caveat_key, identifier)
-        .add_first_party_caveat("time < " + oneHourFromNow)
-        .getMacaroon();
+    Macaroon d = Macaroon.builder("http://auth.mybank/", caveat_key, identifier)
+        .addCaveat("time < " + oneHourFromNow)
+        .build();
 
-    Macaroon dp = MacaroonsBuilder.modify(m)
-        .prepare_for_request(d)
-        .getMacaroon();
+    Macaroon dp = Macaroon.builder(m)
+        .prepareForRequest(d)
+        .build();
 
     System.out.println("d.signature = " + d.signature);
     System.out.println("dp.signature = " + dp.signature);
@@ -172,9 +172,9 @@ public class MacaroonsExamples {
     String secretKey = "this is our super secret key; only we should know it";
     String identifier = "we used our secret key";
 
-    Macaroon macaroon = new MacaroonsBuilder(location, secretKey, identifier)
-        .add_first_party_caveat("time < 2015-01-01T00:00")
-        .getMacaroon();
+    Macaroon macaroon = Macaroon.builder(location, secretKey, identifier)
+        .addCaveat("time < 2015-01-01T00:00")
+        .build();
 
     new MacaroonsVerifier(macaroon)
         .satisfyGeneral(new TimestampCaveatVerifier())
@@ -187,9 +187,9 @@ public class MacaroonsExamples {
     String secretKey = "this is our super secret key; only we should know it";
     String identifier = "we used our secret key";
 
-    Macaroon macaroon = new MacaroonsBuilder(location, secretKey, identifier)
-        .add_first_party_caveat("authorities = ROLE_USER, DEV_TOOLS_AVAILABLE")
-        .getMacaroon();
+    Macaroon macaroon = Macaroon.builder(location, secretKey, identifier)
+        .addCaveat("authorities = ROLE_USER, DEV_TOOLS_AVAILABLE")
+        .build();
 
     new MacaroonsVerifier(macaroon)
         .satisfyGeneral(hasAuthority("DEV_TOOLS_AVAILABLE"))

--- a/src/main/java/com/github/nitram509/jmacaroons/MacaroonsBuilder.java
+++ b/src/main/java/com/github/nitram509/jmacaroons/MacaroonsBuilder.java
@@ -31,22 +31,24 @@ import static com.github.nitram509.jmacaroons.MacaroonsConstants.MACAROON_MAX_ST
  * String location = "http://www.example.org";
  * String secretKey = "this is our super secret key; only we should know it";
  * String identifier = "we used our secret key";
- * Macaroon macaroon = MacaroonsBuilder.create(location, secretKey, identifier);
+ * Macaroon macaroon = Macaroon.create(location, secretKey, identifier);
  * }</pre>
  */
 public class MacaroonsBuilder {
 
-  private Macaroon macaroon = null;
+  private Macaroon macaroon;
 
   /**
+   * @deprecated use {@link Macaroon#builder(String, String, String)}
    * @param location   location
    * @param secretKey  secretKey this secret will be enhanced, in case it's shorter than {@link com.github.nitram509.jmacaroons.MacaroonsConstants#MACAROON_SUGGESTED_SECRET_LENGTH}
    * @param identifier identifier
    * @throws com.github.nitram509.jmacaroons.GeneralSecurityRuntimeException GeneralSecurityRuntimeException
    */
+  @Deprecated
   public MacaroonsBuilder(String location, String secretKey, String identifier) throws GeneralSecurityRuntimeException {
     try {
-      this.macaroon = computeMacaroon(location, generate_derived_key(string_to_bytes(secretKey)), identifier);
+      this.macaroon = new Macaroon(location, generate_derived_key(string_to_bytes(secretKey)), identifier);
     }
     catch (InvalidKeyException | NoSuchAlgorithmException e) {
       throw new GeneralSecurityRuntimeException(e);
@@ -54,14 +56,16 @@ public class MacaroonsBuilder {
   }
 
   /**
+   * @deprecated use {@link Macaroon#builder(String, byte[], String)}
    * @param location   location
    * @param secretKey  secretKey this secret will be used as it is (be sure that has suggested length {@link com.github.nitram509.jmacaroons.MacaroonsConstants#MACAROON_SUGGESTED_SECRET_LENGTH})
    * @param identifier identifier
    * @throws com.github.nitram509.jmacaroons.GeneralSecurityRuntimeException GeneralSecurityRuntimeException
    */
+  @Deprecated
   public MacaroonsBuilder(String location, byte[] secretKey, String identifier) throws GeneralSecurityRuntimeException {
     try {
-      this.macaroon = computeMacaroon(location, generate_derived_key(secretKey), identifier);
+      this.macaroon = new Macaroon(location, generate_derived_key(secretKey), identifier);
     }
     catch (InvalidKeyException | NoSuchAlgorithmException e) {
       throw new GeneralSecurityRuntimeException(e);
@@ -69,80 +73,91 @@ public class MacaroonsBuilder {
   }
 
   /**
+   * @deprecated use {@link Macaroon#builder(Macaroon)}
    * @param macaroon macaroon to modify
    */
+  @Deprecated
   public MacaroonsBuilder(Macaroon macaroon) {
     assert macaroon != null;
     this.macaroon = macaroon;
   }
 
   /**
+   * @deprecated use {@link Macaroon#create(String, String, String)} )}
    * @param location   location
    * @param secretKey  secretKey
    * @param identifier identifier
    * @return {@link com.github.nitram509.jmacaroons.Macaroon}
    */
+  @Deprecated
   public static Macaroon create(String location, String secretKey, String identifier) {
-    try {
-      return computeMacaroon(location, generate_derived_key(string_to_bytes(secretKey)), identifier);
-    }
-    catch (InvalidKeyException | NoSuchAlgorithmException e) {
-      throw new GeneralSecurityRuntimeException(e);
-    }
+    return Macaroon.create(location, secretKey, identifier);
   }
 
   /**
+   * @deprecated use {@link Macaroon#create(String, byte[], String)} )}
    * @param location   location
    * @param secretKey  secretKey
    * @param identifier identifier
    * @return {@link com.github.nitram509.jmacaroons.Macaroon}
    */
+  @Deprecated
   public static Macaroon create(String location, byte[] secretKey, String identifier) {
-    try {
-      return computeMacaroon(location, generate_derived_key(secretKey), identifier);
-    }
-    catch (InvalidKeyException | NoSuchAlgorithmException e) {
-      throw new GeneralSecurityRuntimeException(e);
-    }
+    return Macaroon.create(location, secretKey, identifier);
   }
 
   /**
+   * @deprecated use {@link Macaroon#builder(Macaroon)}
    * @param macaroon macaroon
    * @return {@link com.github.nitram509.jmacaroons.MacaroonsBuilder}
    */
+  @Deprecated
   public static MacaroonsBuilder modify(Macaroon macaroon) {
-    return new MacaroonsBuilder(macaroon);
+    return Macaroon.builder(macaroon);
   }
 
   /**
    * Deserializes a macaroon using the {@link MacaroonsSerializer#V1} format.
    *
+   * @deprecated use {@link Macaroon#deserialize(String)}
    * @param serializedMacaroon serializedMacaroon
    * @return {@link com.github.nitram509.jmacaroons.Macaroon}
    * @throws com.github.nitram509.jmacaroons.NotDeSerializableException when serialized macaroon is not valid base64, length is to short or contains invalid packet data
    * @see #deserialize(String, MacaroonsSerializer)
    */
+  @Deprecated
   public static Macaroon deserialize(String serializedMacaroon) throws IllegalArgumentException {
-    return deserialize(serializedMacaroon, MacaroonsSerializer.V1);
+    return Macaroon.deserialize(serializedMacaroon);
   }
 
   /**
    * Deserializes a macaroon using the given format.
    *
+   * @deprecated use {@link Macaroon#deserialize(String, MacaroonsSerializer)}
    * @param serializedMacaroon serializedMacaroon
    * @param format the serialization format.
    * @return {@link com.github.nitram509.jmacaroons.Macaroon}
    * @throws com.github.nitram509.jmacaroons.NotDeSerializableException when serialized macaroon is not valid, length is to short or contains invalid packet data
    * @see #deserialize(String, MacaroonsSerializer)
    */
+  @Deprecated
   public static Macaroon deserialize(String serializedMacaroon, MacaroonsSerializer format) throws IllegalArgumentException {
-    return format.deserialize(serializedMacaroon);
+    return Macaroon.deserialize(serializedMacaroon, format);
+  }
+
+  /**
+   * @deprecated use {@link #build()}
+   * @return a {@link com.github.nitram509.jmacaroons.Macaroon}
+   */
+  @Deprecated
+  public Macaroon getMacaroon() {
+    return build();
   }
 
   /**
    * @return a {@link com.github.nitram509.jmacaroons.Macaroon}
    */
-  public Macaroon getMacaroon() {
+  public Macaroon build() {
     return macaroon;
   }
 
@@ -152,7 +167,7 @@ public class MacaroonsBuilder {
    * @throws com.github.nitram509.jmacaroons.GeneralSecurityRuntimeException GeneralSecurityRuntimeException
    * @throws IllegalStateException                                           if there are more than {@link com.github.nitram509.jmacaroons.MacaroonsConstants#MACAROON_MAX_CAVEATS} caveats.
    */
-  public MacaroonsBuilder add_first_party_caveat(String caveat) throws IllegalStateException, GeneralSecurityRuntimeException {
+  public MacaroonsBuilder addCaveat(String caveat) throws IllegalStateException, GeneralSecurityRuntimeException {
     if (caveat != null) {
       byte[] caveatBytes = caveat.getBytes(MacaroonsConstants.IDENTIFIER_CHARSET);
       assert caveatBytes.length < MACAROON_MAX_STRLEN;
@@ -171,6 +186,18 @@ public class MacaroonsBuilder {
   }
 
   /**
+   * @deprecated use {@link #addCaveat(String)}
+   * @param caveat caveat
+   * @return this {@link com.github.nitram509.jmacaroons.MacaroonsBuilder}
+   * @throws com.github.nitram509.jmacaroons.GeneralSecurityRuntimeException GeneralSecurityRuntimeException
+   * @throws IllegalStateException                                           if there are more than {@link com.github.nitram509.jmacaroons.MacaroonsConstants#MACAROON_MAX_CAVEATS} caveats.
+   */
+  @Deprecated
+  public MacaroonsBuilder add_first_party_caveat(String caveat) throws IllegalStateException, GeneralSecurityRuntimeException {
+    return addCaveat(caveat);
+  }
+
+  /**
    * @param location   location
    * @param secret     secret
    * @param identifier identifier
@@ -178,8 +205,7 @@ public class MacaroonsBuilder {
    * @throws com.github.nitram509.jmacaroons.GeneralSecurityRuntimeException GeneralSecurityRuntimeException
    * @throws IllegalStateException                                           if there are more than {@link com.github.nitram509.jmacaroons.MacaroonsConstants#MACAROON_MAX_CAVEATS} caveats.
    */
-  public MacaroonsBuilder add_third_party_caveat(String location, String secret, String identifier) throws IllegalStateException, GeneralSecurityRuntimeException {
-
+  public MacaroonsBuilder addCaveat(String location, String secret, String identifier) throws IllegalStateException, GeneralSecurityRuntimeException {
     assert location.length() < MACAROON_MAX_STRLEN;
     assert identifier.length() < MACAROON_MAX_STRLEN;
 
@@ -203,31 +229,45 @@ public class MacaroonsBuilder {
   }
 
   /**
-   * @param macaroon macaroon used for preparing a request
+   * @deprecated use {@link #addCaveat(String, String, String)}
+   * @param location   location
+   * @param secret     secret
+   * @param identifier identifier
+   * @return this {@link com.github.nitram509.jmacaroons.MacaroonsBuilder}
+   * @throws com.github.nitram509.jmacaroons.GeneralSecurityRuntimeException GeneralSecurityRuntimeException
+   * @throws IllegalStateException                                           if there are more than {@link com.github.nitram509.jmacaroons.MacaroonsConstants#MACAROON_MAX_CAVEATS} caveats.
+   */
+  @Deprecated
+  public MacaroonsBuilder add_third_party_caveat(String location, String secret, String identifier) throws IllegalStateException, GeneralSecurityRuntimeException {
+    return addCaveat(location, secret, identifier);
+  }
+
+  /**
+   * @param other macaroon used for preparing a request
    * @return this {@link com.github.nitram509.jmacaroons.MacaroonsBuilder}
    * @throws com.github.nitram509.jmacaroons.GeneralSecurityRuntimeException GeneralSecurityRuntimeException
    */
-  public MacaroonsBuilder prepare_for_request(Macaroon macaroon) throws GeneralSecurityRuntimeException {
+  public MacaroonsBuilder prepareForRequest(Macaroon other) throws GeneralSecurityRuntimeException {
+    assert other.signatureBytes.length > 0;
     assert macaroon.signatureBytes.length > 0;
-    assert getMacaroon().signatureBytes.length > 0;
     try {
-      byte[] hash = macaroon_bind(getMacaroon().signatureBytes, macaroon.signatureBytes);
-      this.macaroon = new Macaroon(macaroon.location, macaroon.identifier, hash, macaroon.caveatPackets);
+      byte[] hash = macaroon_bind(macaroon.signatureBytes, other.signatureBytes);
+      this.macaroon = new Macaroon(other.location, other.identifier, hash, other.caveatPackets);
       return this;
     } catch (InvalidKeyException | NoSuchAlgorithmException e) {
       throw new GeneralSecurityRuntimeException(e);
     }
   }
 
-  private static Macaroon computeMacaroon(String location, byte[] secretKey, String identifier) throws GeneralSecurityRuntimeException {
-    assert location.length() < MACAROON_MAX_STRLEN;
-    assert identifier.length() < MACAROON_MAX_STRLEN;
-    try {
-      byte[] hash = macaroon_hmac(secretKey, identifier);
-      return new Macaroon(location, identifier, hash);
-    } catch (InvalidKeyException | NoSuchAlgorithmException e) {
-      throw new GeneralSecurityRuntimeException(e);
-    }
+  /**
+   * @deprecated use {@link #prepareForRequest(Macaroon)}
+   * @param macaroon macaroon used for preparing a request
+   * @return this {@link com.github.nitram509.jmacaroons.MacaroonsBuilder}
+   * @throws com.github.nitram509.jmacaroons.GeneralSecurityRuntimeException GeneralSecurityRuntimeException
+   */
+  @Deprecated
+  public MacaroonsBuilder prepare_for_request(Macaroon macaroon) throws GeneralSecurityRuntimeException {
+    return prepareForRequest(macaroon);
   }
 
 }

--- a/src/main/java/com/github/nitram509/jmacaroons/verifier/TimestampCaveatVerifier.java
+++ b/src/main/java/com/github/nitram509/jmacaroons/verifier/TimestampCaveatVerifier.java
@@ -60,9 +60,9 @@ import java.util.Date;
  * <br>
  * <strong>Applying a time based caveat</strong>
  * <pre>{@code
- * Macaroon m = new MacaroonsBuilder("location", "secret", "identifiert")
- *    .add_first_party_caveat("time &lt; 2042-09-23T17:42:35")
- *    .getMacaroon();
+ * Macaroon m = new Macaroon.builder("location", "secret", "identifiert")
+ *    .addCaveat("time &lt; 2042-09-23T17:42:35")
+ *    .build();
  * new MacaroonsVerifier(m)
  *    .satisfyGeneral(new TimestampCaveatVerifier())
  *    .assertIsValid("secret");

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsBuilder3rdPartyCaveatsTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsBuilder3rdPartyCaveatsTest.java
@@ -33,10 +33,10 @@ public class MacaroonsBuilder3rdPartyCaveatsTest {
     String caveat_key = "4; guaranteed random by a fair toss of the dice";
     String predicate = "user = Alice";
     String identifier = "this was how we remind auth of key/pred";
-    Macaroon m = new MacaroonsBuilder(location, secret, publicIdentifier)
-        .add_first_party_caveat("account = 3735928559")
-        .add_third_party_caveat("http://auth.mybank/", caveat_key, identifier)
-        .getMacaroon();
+    Macaroon m = Macaroon.builder(location, secret, publicIdentifier)
+        .addCaveat("account = 3735928559")
+        .addCaveat("http://auth.mybank/", caveat_key, identifier)
+        .build();
 
     assertThat(m.identifier).isEqualTo(publicIdentifier);
     assertThat(m.location).isEqualTo(location);

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsBuilderCaveatsTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsBuilderCaveatsTest.java
@@ -38,9 +38,9 @@ public class MacaroonsBuilderCaveatsTest {
 
   @Test
   public void add_first_party_caveat() {
-    m = new MacaroonsBuilder(location, secret, identifier)
-        .add_first_party_caveat("account = 3735928559")
-        .getMacaroon();
+    m = Macaroon.builder(location, secret, identifier)
+        .addCaveat("account = 3735928559")
+        .build();
 
     assertThat(m.identifier).isEqualTo(m.identifier);
     assertThat(m.location).isEqualTo(m.location);
@@ -51,13 +51,13 @@ public class MacaroonsBuilderCaveatsTest {
   @Test
   public void modify_also_copies_first_party_caveats() {
     // given
-    m = new MacaroonsBuilder(location, secret, identifier)
-        .add_first_party_caveat("account = 3735928559")
-        .getMacaroon();
+    m = Macaroon.builder(location, secret, identifier)
+        .addCaveat("account = 3735928559")
+        .build();
 
     // when
-    m = MacaroonsBuilder.modify(m)
-        .getMacaroon();
+    m = Macaroon.builder(m)
+        .build();
 
     assertThat(m.identifier).isEqualTo(m.identifier);
     assertThat(m.location).isEqualTo(m.location);
@@ -67,11 +67,11 @@ public class MacaroonsBuilderCaveatsTest {
 
   @Test
   public void add_first_party_caveat_3_times() {
-    m = new MacaroonsBuilder(location, secret, identifier)
-        .add_first_party_caveat("account = 3735928559")
-        .add_first_party_caveat("time < 2015-01-01T00:00")
-        .add_first_party_caveat("email = alice@example.org")
-        .getMacaroon();
+    m = Macaroon.builder(location, secret, identifier)
+        .addCaveat("account = 3735928559")
+        .addCaveat("time < 2015-01-01T00:00")
+        .addCaveat("email = alice@example.org")
+        .build();
 
     assertThat(m.identifier).isEqualTo(m.identifier);
     assertThat(m.location).isEqualTo(m.location);
@@ -85,11 +85,11 @@ public class MacaroonsBuilderCaveatsTest {
 
   @Test
   public void add_first_party_caveat_German_umlauts_using_UTF8_encoding() {
-    MacaroonsBuilder mb = new MacaroonsBuilder(location, secret, identifier);
-    mb = mb.add_first_party_caveat("\u00E4");
-    mb = mb.add_first_party_caveat("\u00FC");
-    mb = mb.add_first_party_caveat("\u00F6");
-    m = mb.getMacaroon();
+    MacaroonsBuilder mb = Macaroon.builder(location, secret, identifier);
+    mb = mb.addCaveat("\u00E4");
+    mb = mb.addCaveat("\u00FC");
+    mb = mb.addCaveat("\u00F6");
+    m = mb.build();
 
     assertThat(m.identifier).isEqualTo(m.identifier);
     assertThat(m.location).isEqualTo(m.location);
@@ -103,9 +103,9 @@ public class MacaroonsBuilderCaveatsTest {
 
   @Test
   public void add_first_party_caveat_null_save() {
-    m = new MacaroonsBuilder(location, secret, identifier)
-        .add_first_party_caveat(null)
-        .getMacaroon();
+    m = Macaroon.builder(location, secret, identifier)
+        .addCaveat(null)
+        .build();
 
     assertThat(m.identifier).isEqualTo(m.identifier);
     assertThat(m.location).isEqualTo(m.location);
@@ -114,9 +114,9 @@ public class MacaroonsBuilderCaveatsTest {
 
   @Test
   public void add_first_party_caveat_inspect() {
-    m = new MacaroonsBuilder(location, secret, identifier)
-        .add_first_party_caveat("account = 3735928559")
-        .getMacaroon();
+    m = Macaroon.builder(location, secret, identifier)
+        .addCaveat("account = 3735928559")
+        .build();
 
     String inspect = m.inspect();
 

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsBuilderTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsBuilderTest.java
@@ -20,6 +20,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -39,7 +40,7 @@ public class MacaroonsBuilderTest {
 
   @Test
   public void create_a_Macaroon_and_verify_signature_location_and_identfier() {
-    m = new MacaroonsBuilder(location, secret, identifier).getMacaroon();
+    m = Macaroon.builder(location, secret, identifier).build();
 
     assertThat(m.location).isEqualTo(location);
     assertThat(m.identifier).isEqualTo(identifier);
@@ -48,7 +49,7 @@ public class MacaroonsBuilderTest {
 
   @Test
   public void create_a_Macaroon_with_static_helper_method() {
-    m = MacaroonsBuilder.create("http://example.org/", "example secret key", "example entifier");
+    m = Macaroon.create("http://example.org/", "example secret key", "example entifier");
 
     assertThat(m.location).isEqualTo("http://example.org/");
     assertThat(m.identifier).isEqualTo("example entifier");
@@ -57,7 +58,7 @@ public class MacaroonsBuilderTest {
 
   @Test
   public void create_a_Macaroon_and_inspect() {
-    m = new MacaroonsBuilder(location, secret, identifier).getMacaroon();
+    m = Macaroon.builder(location, secret, identifier).build();
 
     String inspect = m.inspect();
 
@@ -70,15 +71,15 @@ public class MacaroonsBuilderTest {
 
   @Test
   public void different_locations_doesnt_change_the_signatures() {
-    Macaroon m1 = new MacaroonsBuilder("http://location_ONE", secret, identifier).getMacaroon();
-    Macaroon m2 = new MacaroonsBuilder("http://location_TWO", secret, identifier).getMacaroon();
+    Macaroon m1 = Macaroon.builder("http://location_ONE", secret, identifier).build();
+    Macaroon m2 = Macaroon.builder("http://location_TWO", secret, identifier).build();
 
     assertThat(m1.signature).isEqualTo(m2.signature);
   }
 
   @Test
   public void Macaroon_can_be_serialized() {
-    m = new MacaroonsBuilder(location, secret, identifier).getMacaroon();
+    m = Macaroon.builder(location, secret, identifier).build();
 
     assertThat(m.serialize()).isEqualTo("MDAxY2xvY2F0aW9uIGh0dHA6Ly9teWJhbmsvCjAwMjZpZGVudGlmaWVyIHdlIHVzZWQgb3VyIHNlY3JldCBrZXkKMDAyZnNpZ25hdHVyZSDj2eApCFJsTAA5rhURQRXZf91ovyujebNCqvD2F9BVLwo");
   }
@@ -86,10 +87,10 @@ public class MacaroonsBuilderTest {
   @Test
   public void create_a_Macaroon_from_a_byteArray() throws UnsupportedEncodingException {
     identifier ="we used our secret key";
-    byte[] secretBytes = secret.getBytes("ASCII");
+    byte[] secretBytes = secret.getBytes(StandardCharsets.US_ASCII);
     location ="http://www.example.org";
 
-    m = MacaroonsBuilder.create(location, secretBytes, identifier);
+    m = Macaroon.create(location, secretBytes, identifier);
 
     assertThat(m.signature).isEqualTo("e3d9e02908526c4c0039ae15114115d97fdd68bf2ba379b342aaf0f617d0552f");
   }

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsPrepareRequestAndVerifyComplexTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsPrepareRequestAndVerifyComplexTest.java
@@ -22,8 +22,6 @@ import org.testng.annotations.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
 
-import java.time.Duration;
-import java.time.Instant;
 
 public class MacaroonsPrepareRequestAndVerifyComplexTest {
 
@@ -42,18 +40,18 @@ public class MacaroonsPrepareRequestAndVerifyComplexTest {
     location = "http://mybank/";
     secret = "this is a different super-secret key; never use the same secret twice";
     publicIdentifier = "we used our other secret key";
-    M = new MacaroonsBuilder(location, secret, publicIdentifier)
-        .add_first_party_caveat("account = 3735928559")
-        .getMacaroon();
+    M = Macaroon.builder(location, secret, publicIdentifier)
+        .addCaveat("account = 3735928559")
+        .build();
     assertThat(M.signature).isEqualTo("1434e674ad84fdfdc9bc1aa00785325c8b6d57341fc7ce200ba4680c80786dda");
 
     caveat_key = "4; guaranteed random by a fair toss of the dice";
     identifier = "this was how we remind auth of key/pred";
 
-    M = new MacaroonsBuilder(M)
-        .add_third_party_caveat("http://auth.mybank/", caveat_key, identifier)
-        .add_first_party_caveat("role = admin")
-        .getMacaroon();
+    M = Macaroon.builder(M)
+        .addCaveat("http://auth.mybank/", caveat_key, identifier)
+        .addCaveat("role = admin")
+        .build();
     // signature can't be asserted to be equal to a constant, because random nonce influences signature
   }
 
@@ -62,17 +60,17 @@ public class MacaroonsPrepareRequestAndVerifyComplexTest {
     caveat_key = "4; guaranteed random by a fair toss of the dice";
     identifier = "this was how we remind auth of key/pred";
 
-    D = new MacaroonsBuilder("http://auth.mybank/", caveat_key, identifier)
-        .add_first_party_caveat("time < 2025-01-01T00:00")
-        .getMacaroon();
+    D = Macaroon.builder("http://auth.mybank/", caveat_key, identifier)
+        .addCaveat("time < 2025-01-01T00:00")
+        .build();
 
     assertThat(D.signature)
         .describedAs("a known caveat always creates a known signature")
         .isEqualTo("b338d11fb136c4b95c86efe146f77978cd0947585375ba4d4da4ef68be2b3e8b");
 
-    DP = new MacaroonsBuilder(M)
-        .prepare_for_request(D)
-        .getMacaroon();
+    DP = Macaroon.builder(M)
+        .prepareForRequest(D)
+        .build();
 
     // signature can't be asserted to be equal to a constant, because random nonce influences signature
   }

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsSerializerTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsSerializerTest.java
@@ -57,8 +57,8 @@ public class MacaroonsSerializerTest {
         // Given
 
         // When
-        Macaroon v1Macaroon = MacaroonsBuilder.deserialize(v1, MacaroonsSerializer.V1);
-        Macaroon v2Macaroon = MacaroonsBuilder.deserialize(v2, MacaroonsSerializer.V2);
+        Macaroon v1Macaroon = Macaroon.deserialize(v1, MacaroonsSerializer.V1);
+        Macaroon v2Macaroon = Macaroon.deserialize(v2, MacaroonsSerializer.V2);
 
         // Then
         assertThat(v1Macaroon).isEqualTo(v2Macaroon);

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsSerializerV1Test.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsSerializerV1Test.java
@@ -37,7 +37,7 @@ public class MacaroonsSerializerV1Test {
 
   @Test
   public void Macaroon_can_be_serialized() {
-    Macaroon m = new MacaroonsBuilder(location, secret, identifier).getMacaroon();
+    Macaroon m = Macaroon.builder(location, secret, identifier).build();
 
     assertThat(MacaroonsSerializer.V1.serialize(m)).isEqualTo(
             "MDAxY2xvY2F0aW9uIGh0dHA6Ly9teWJhbmsvCjAwMjZpZGVudGlmaWVyIHdlIHVzZWQgb3VyIHNlY3JldCBrZXkKMDAyZnNpZ25hdHVyZSDj2eApCFJsTAA5rhURQRXZf91ovyujebNCqvD2F9BVLwo");
@@ -46,9 +46,9 @@ public class MacaroonsSerializerV1Test {
 
   @Test
   public void Macaroon_with_caveat_can_be_serialized() {
-    Macaroon m = new MacaroonsBuilder(location, secret, identifier)
-        .add_first_party_caveat("account = 3735928559")
-        .getMacaroon();
+    Macaroon m = Macaroon.builder(location, secret, identifier)
+        .addCaveat("account = 3735928559")
+        .build();
 
     assertThat(MacaroonsSerializer.V1.serialize(m)).isEqualTo(
             "MDAxY2xvY2F0aW9uIGh0dHA6Ly9teWJhbmsvCjAwMjZpZGVudGlmaWVyIHdlIHVzZWQgb3VyIHNlY3JldCBrZXkKMDAxZGNpZCBhY2NvdW50ID0gMzczNTkyODU1OQowMDJmc2lnbmF0dXJlIB7-R2PykNvODB0IR3Nn4R9O7kVqZJM89mLXl3LbuCEoCg");
@@ -57,10 +57,10 @@ public class MacaroonsSerializerV1Test {
 
   @Test
   public void Macaroon_with_3rd_party_caveat_can_be_serialized() {
-    Macaroon m = new MacaroonsBuilder(location, secret, identifier)
-        .add_first_party_caveat("account = 3735928559")
-        .add_third_party_caveat("http://auth.mybank/", "SECRET for 3rd party caveat", identifier)
-        .getMacaroon();
+    Macaroon m = Macaroon.builder(location, secret, identifier)
+        .addCaveat("account = 3735928559")
+        .addCaveat("http://auth.mybank/", "SECRET for 3rd party caveat", identifier)
+        .build();
 
     assertThat(MacaroonsSerializer.V1.serialize(m)).startsWith(
             "MDAxY2xvY2F0aW9uIGh0dHA6Ly9teWJhbmsvCjAwMjZpZGVudGlmaWVyIHdlIHVzZWQgb3VyIHNlY3JldCBrZXkKMDAxZGNpZCBhY2NvdW50ID0gMzczNTkyODU1OQowMDFmY2lkIHdlIHVzZWQgb3VyIHNlY3JldCBrZXkKMDA1MXZpZC");
@@ -70,7 +70,7 @@ public class MacaroonsSerializerV1Test {
 
   @Test
   public void Macaroon_can_be_deserialized() {
-    m = new MacaroonsBuilder(location, secret, identifier).getMacaroon();
+    m = Macaroon.builder(location, secret, identifier).build();
     String serialized = m.serialize();
 
     Macaroon deserialized = MacaroonsSerializer.V1.deserialize(serialized);
@@ -80,9 +80,9 @@ public class MacaroonsSerializerV1Test {
 
   @Test
   public void Macaroon_with_1st_party_caveat_can_be_deserialized() {
-    m = new MacaroonsBuilder(location, secret, identifier)
-            .add_first_party_caveat("account = 3735928559")
-            .getMacaroon();
+    m = Macaroon.builder(location, secret, identifier)
+            .addCaveat("account = 3735928559")
+            .build();
     String serialized = m.serialize();
 
     Macaroon deserialized = MacaroonsSerializer.V1.deserialize(serialized);
@@ -92,10 +92,10 @@ public class MacaroonsSerializerV1Test {
 
   @Test
   public void Macaroon_with_3rd_party_caveat_can_be_deserialized() {
-    m = new MacaroonsBuilder(location, secret, identifier)
-            .add_first_party_caveat("account = 3735928559")
-            .add_third_party_caveat("http://auth.mybank/", "SECRET for 3rd party caveat", identifier)
-            .getMacaroon();
+    m = Macaroon.builder(location, secret, identifier)
+            .addCaveat("account = 3735928559")
+            .addCaveat("http://auth.mybank/", "SECRET for 3rd party caveat", identifier)
+            .build();
     String serialized = m.serialize();
 
     Macaroon deserialized = MacaroonsSerializer.V1.deserialize(serialized);

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsSerializerV2Test.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsSerializerV2Test.java
@@ -41,15 +41,15 @@ public class MacaroonsSerializerV2Test {
         byte[] key = new byte[32];
         Arrays.fill(key, (byte) 42);
         String caveatKey = "super secret caveat key";
-        Macaroon macaroon = MacaroonsBuilder.create(LOCATION, key, IDENTIFIER);
-        macaroon = MacaroonsBuilder.modify(macaroon)
-                .add_first_party_caveat(FIRST_PARTY_CAVEAT)
-                .add_third_party_caveat(THIRD_PARTY_LOCATION, caveatKey, THIRD_PARTY_CAVEAT)
-                .getMacaroon();
+        Macaroon macaroon = Macaroon.create(LOCATION, key, IDENTIFIER);
+        macaroon = Macaroon.builder(macaroon)
+                .addCaveat(FIRST_PARTY_CAVEAT)
+                .addCaveat(THIRD_PARTY_LOCATION, caveatKey, THIRD_PARTY_CAVEAT)
+                .build();
 
         // When
         String serialized = macaroon.serialize(MacaroonsSerializer.V2);
-        Macaroon deserialized = MacaroonsBuilder.deserialize(serialized, MacaroonsSerializer.V2);
+        Macaroon deserialized = Macaroon.deserialize(serialized, MacaroonsSerializer.V2);
 
         // Then
         assertThat(deserialized.signature).as("signature").isEqualTo(macaroon.signature);

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsVerifierTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsVerifierTest.java
@@ -46,7 +46,7 @@ public class MacaroonsVerifierTest {
 
   @Test
   public void verification() {
-    m = new MacaroonsBuilder(location, secret, identifier).getMacaroon();
+    m = Macaroon.builder(location, secret, identifier).build();
 
     MacaroonsVerifier verifier = new MacaroonsVerifier(m);
     assertThat(verifier.isValid(secret)).isTrue();
@@ -54,7 +54,7 @@ public class MacaroonsVerifierTest {
 
   @Test
   public void verification_with_byteArray() {
-    m = new MacaroonsBuilder(location, secretBytes, identifier).getMacaroon();
+    m = Macaroon.builder(location, secretBytes, identifier).build();
 
     MacaroonsVerifier verifier = new MacaroonsVerifier(m);
     assertThat(verifier.isValid(secretBytes)).isTrue();
@@ -62,7 +62,7 @@ public class MacaroonsVerifierTest {
 
   @Test(expectedExceptions = MacaroonValidationException.class)
   public void verification_assertion() {
-    m = new MacaroonsBuilder(location, secret, identifier).getMacaroon();
+    m = Macaroon.builder(location, secret, identifier).build();
 
     MacaroonsVerifier verifier = new MacaroonsVerifier(m);
     verifier.assertIsValid("wrong secret");
@@ -72,9 +72,9 @@ public class MacaroonsVerifierTest {
 
   @Test
   public void verification_satisfy_exact_first_party_caveat() {
-    m = new MacaroonsBuilder(location, secret, identifier)
-        .add_first_party_caveat("account = 3735928559")
-        .getMacaroon();
+    m = Macaroon.builder(location, secret, identifier)
+        .addCaveat("account = 3735928559")
+        .build();
 
     MacaroonsVerifier verifier = new MacaroonsVerifier(m);
     assertThat(verifier.isValid(secret)).isFalse();
@@ -85,10 +85,10 @@ public class MacaroonsVerifierTest {
 
   @Test
   public void verification_satisfy_exact_required_first_party_caveat_() {
-    m = new MacaroonsBuilder(location, secret, identifier)
-        .add_first_party_caveat("account = 3735928559")
-        .add_first_party_caveat("credit_allowed = true")
-        .getMacaroon();
+    m = Macaroon.builder(location, secret, identifier)
+        .addCaveat("account = 3735928559")
+        .addCaveat("credit_allowed = true")
+        .build();
 
     MacaroonsVerifier verifier = new MacaroonsVerifier(m);
     assertThat(verifier.isValid(secret)).isFalse();
@@ -99,9 +99,9 @@ public class MacaroonsVerifierTest {
 
   @Test
   public void verification_satisfy_exact_attenuate_with_additional_caveats() {
-    m = new MacaroonsBuilder(location, secret, identifier)
-        .add_first_party_caveat("account = 3735928559")
-        .getMacaroon();
+    m = Macaroon.builder(location, secret, identifier)
+        .addCaveat("account = 3735928559")
+        .build();
 
     MacaroonsVerifier verifier = new MacaroonsVerifier(m);
     assertThat(verifier.isValid(secret)).isFalse();
@@ -115,9 +115,9 @@ public class MacaroonsVerifierTest {
 
   @Test
   public void verification_general() {
-    m = new MacaroonsBuilder(location, secret, identifier)
-        .add_first_party_caveat("time < " + createTimeStamp1WeekInFuture())
-        .getMacaroon();
+    m = Macaroon.builder(location, secret, identifier)
+        .addCaveat("time < " + createTimeStamp1WeekInFuture())
+        .build();
 
     MacaroonsVerifier verifier = new MacaroonsVerifier(m);
     assertThat(verifier.isValid(secret)).isFalse();


### PR DESCRIPTION
Use a more familiar builder API and Java methods name, essentially not exposing `MacaroonsBuilder` directly but via `Macaroon.builder()` methods, and changing the builders method to be more inline with Java naming conventions.

```java
Macaroon macaroon = Macaroon.builder(location, secretKey, identifier)
    .addCaveat("time < 2042-01-01T00:00")
    .addCaveat("http://auth.mybank/", caveat_key, identifier)
    .build();
```

This also moves all static methods that returns a `Macaroon` directly has a static method of `Macaroon` itself:

```java
Macaroon.create(location, secretKey, identifier);
Macaroon.deserialize(serialized);
```

This is entirely backward compatible for now, but all methods that would need to be changed or removed in the future have been marked as deprecated.