### PR TITLE
Use a more familiar verifier API

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ Alternatively, the V2 binary serializer format is supported.
     String serialized = macaroon.serialize(V2);
     System.out.println("Serialized: " + serialized);
     // Serialized: AgEWaHR0cDovL3d3dy5leGFtcGxlLm9yZwIWd2UgdXNlZCBvdXIgc2VjcmV0IGtleQAABiDj2eApCFJsTAA5rhURQRXZf91ovyujebNCqvD2F9BVLw
-  }
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
@@ -146,11 +145,11 @@ when provided with the macaroon and its corresponding secret - no secret, no aut
 ```java
   void verify() throws InvalidKeyException, NoSuchAlgorithmException {
     Macaroon macaroon = create();
-    MacaroonsVerifier verifier = new MacaroonsVerifier(macaroon);
+
+    MacaroonsVerifier verifier = macaroon.verifier();
     String secret = "this is our super secret key; only we should know it";
     boolean valid = verifier.isValid(secret);
     // > True
-  }
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
@@ -171,7 +170,6 @@ restricts it to just the account number 3735928559.
         .addCaveat("account = 3735928559")
         .build();
     System.out.println(macaroon.inspect());
-  }
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
@@ -190,7 +188,6 @@ via Macaroon Builder. Thus, a new macaroon object will be created.
     // > identifier we used our secret key
     // > cid account = 3735928559
     // > signature 1efe4763f290dbce0c1d08477367e11f4eee456a64933cf662d79772dbb82128
-  }
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
@@ -211,9 +208,8 @@ We can see that it fails just as we would expect.
     Macaroon macaroon = Macaroon.builder(location, secretKey, identifier)
         .addCaveat("account = 3735928559")
         .build();
-    MacaroonsVerifier verifier = new MacaroonsVerifier(macaroon);
+    MacaroonsVerifier verifier = macaroon.verifier();
     verifier.isValid(secretKey);
-    // > False
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
@@ -226,9 +222,8 @@ the macaroon.
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./src/example/java/com/github/nitram509/jmacaroons/examples/MacaroonsExamples.java&lines=106-108) -->
 <!-- The below code snippet is automatically added from ./src/example/java/com/github/nitram509/jmacaroons/examples/MacaroonsExamples.java -->
 ```java
-    verifier.satisfyExact("account = 3735928559");
+    verifier.satisfy("account = 3735928559");
     verifier.isValid(secretKey);
-    // > True
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
@@ -240,12 +235,11 @@ self-attenuate itself macaroons to be only usable from IP address and browser:
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./src/example/java/com/github/nitram509/jmacaroons/examples/MacaroonsExamples.java&lines=110-115) -->
 <!-- The below code snippet is automatically added from ./src/example/java/com/github/nitram509/jmacaroons/examples/MacaroonsExamples.java -->
 ```java
-    verifier.satisfyExact("IP = 127.0.0.1')");
-    verifier.satisfyExact("browser = Chrome')");
-    verifier.satisfyExact("action = deposit");
+    verifier.satisfy("IP = 127.0.0.1')");
+    verifier.satisfy("browser = Chrome')");
+    verifier.satisfy("action = deposit");
     verifier.isValid(secretKey);
     // > True
-  }
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
@@ -263,14 +257,13 @@ it is able to check if the caveat satisfies special constrains.
     Macaroon macaroon = Macaroon.builder(location, secretKey, identifier)
         .addCaveat("time < 2042-01-01T00:00")
         .build();
-    MacaroonsVerifier verifier = new MacaroonsVerifier(macaroon);
+    MacaroonsVerifier verifier = macaroon.verifier();
     verifier.isValid(secretKey);
     // > False
 
-    verifier.satisfyGeneral(new TimestampCaveatVerifier());
+    verifier.satisfy(new TimestampCaveatVerifier());
     verifier.isValid(secretKey);
     // > True
-  }
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
     
@@ -323,7 +316,6 @@ limited to Alice's bank account.
     // > cid this was how we remind auth of key/pred
     // > vid AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA027FAuBYhtHwJ58FX6UlVNFtFsGxQHS7uD_w_dedwv4Jjw7UorCREw5rXbRqIKhr
     // > cl http://auth.mybank/
-    // > signature d27db2fd1f22760e4c3dae8137e2d8fc1df6c0741c18aed4b97256bf78d1f55c
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
@@ -342,7 +334,6 @@ and return a new macaroon that discharges the caveat:
 
     Macaroon d = Macaroon.builder("http://auth.mybank/", caveat_key, identifier)
         .addCaveat("time < " + oneHourFromNow)
-        .build();
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
@@ -366,7 +357,6 @@ used to bind the discharge macaroons like this:
 ```java
     Macaroon dp = Macaroon.builder(m)
         .prepareForRequest(d)
-        .build();
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
@@ -379,7 +369,6 @@ would see that the binding process has irreversibly altered their signature(s).
     System.out.println("d.signature = " + d.signature);
     System.out.println("dp.signature = " + dp.signature);
     // > d.signature = 82a80681f9f32d419af12f6a71787a1bac3ab199df934ed950ddf20c25ac8c65
-    // > dp.signature = 2eb01d0dd2b4475330739140188648cf25dda0425ea9f661f1574ca0a9eac54e
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
@@ -392,13 +381,12 @@ argument to the verify call:
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./src/example/java/com/github/nitram509/jmacaroons/examples/MacaroonsExamples.java&lines=178-184) -->
 <!-- The below code snippet is automatically added from ./src/example/java/com/github/nitram509/jmacaroons/examples/MacaroonsExamples.java -->
 ```java
-    new MacaroonsVerifier(m)
-        .satisfyExact("account = 3735928559")
-        .satisfyGeneral(new TimestampCaveatVerifier())
-        .satisfy3rdParty(dp)
+    m.verifier()
+        .satisfy("account = 3735928559")
+        .satisfy(new TimestampCaveatVerifier())
+        .satisfy(dp)
         .assertIsValid(secret);
     // > ok.
-  }
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
@@ -426,11 +414,10 @@ for expiration.
         .addCaveat("time < 2015-01-01T00:00")
         .build();
 
-    new MacaroonsVerifier(macaroon)
-        .satisfyGeneral(new TimestampCaveatVerifier())
+    macaroon.verifier()
+        .satisfy(new TimestampCaveatVerifier())
         .isValid(secretKey);
     // > True
-  }
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
@@ -451,11 +438,10 @@ to check for a single authority.
         .addCaveat("authorities = ROLE_USER, DEV_TOOLS_AVAILABLE")
         .build();
 
-    new MacaroonsVerifier(macaroon)
-        .satisfyGeneral(hasAuthority("DEV_TOOLS_AVAILABLE"))
+    macaroon.verifier()
+        .satisfy(hasAuthority("DEV_TOOLS_AVAILABLE"))
         .isValid(secretKey);
     // > True
-  }
 ```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 

--- a/src/example/java/com/github/nitram509/jmacaroons/examples/MacaroonsExamples.java
+++ b/src/example/java/com/github/nitram509/jmacaroons/examples/MacaroonsExamples.java
@@ -64,7 +64,8 @@ public class MacaroonsExamples {
 
   void verify() throws InvalidKeyException, NoSuchAlgorithmException {
     Macaroon macaroon = create();
-    MacaroonsVerifier verifier = new MacaroonsVerifier(macaroon);
+
+    MacaroonsVerifier verifier = macaroon.verifier();
     String secret = "this is our super secret key; only we should know it";
     boolean valid = verifier.isValid(secret);
     // > True
@@ -99,17 +100,17 @@ public class MacaroonsExamples {
     Macaroon macaroon = Macaroon.builder(location, secretKey, identifier)
         .addCaveat("account = 3735928559")
         .build();
-    MacaroonsVerifier verifier = new MacaroonsVerifier(macaroon);
+    MacaroonsVerifier verifier = macaroon.verifier();
     verifier.isValid(secretKey);
     // > False
 
-    verifier.satisfyExact("account = 3735928559");
+    verifier.satisfy("account = 3735928559");
     verifier.isValid(secretKey);
     // > True
 
-    verifier.satisfyExact("IP = 127.0.0.1')");
-    verifier.satisfyExact("browser = Chrome')");
-    verifier.satisfyExact("action = deposit");
+    verifier.satisfy("IP = 127.0.0.1')");
+    verifier.satisfy("browser = Chrome')");
+    verifier.satisfy("action = deposit");
     verifier.isValid(secretKey);
     // > True
   }
@@ -122,11 +123,11 @@ public class MacaroonsExamples {
     Macaroon macaroon = Macaroon.builder(location, secretKey, identifier)
         .addCaveat("time < 2042-01-01T00:00")
         .build();
-    MacaroonsVerifier verifier = new MacaroonsVerifier(macaroon);
+    MacaroonsVerifier verifier = macaroon.verifier();
     verifier.isValid(secretKey);
     // > False
 
-    verifier.satisfyGeneral(new TimestampCaveatVerifier());
+    verifier.satisfy(new TimestampCaveatVerifier());
     verifier.isValid(secretKey);
     // > True
   }
@@ -175,10 +176,10 @@ public class MacaroonsExamples {
     // > d.signature = 82a80681f9f32d419af12f6a71787a1bac3ab199df934ed950ddf20c25ac8c65
     // > dp.signature = 2eb01d0dd2b4475330739140188648cf25dda0425ea9f661f1574ca0a9eac54e
 
-    new MacaroonsVerifier(m)
-        .satisfyExact("account = 3735928559")
-        .satisfyGeneral(new TimestampCaveatVerifier())
-        .satisfy3rdParty(dp)
+    m.verifier()
+        .satisfy("account = 3735928559")
+        .satisfy(new TimestampCaveatVerifier())
+        .satisfy(dp)
         .assertIsValid(secret);
     // > ok.
   }
@@ -192,8 +193,8 @@ public class MacaroonsExamples {
         .addCaveat("time < 2015-01-01T00:00")
         .build();
 
-    new MacaroonsVerifier(macaroon)
-        .satisfyGeneral(new TimestampCaveatVerifier())
+    macaroon.verifier()
+        .satisfy(new TimestampCaveatVerifier())
         .isValid(secretKey);
     // > True
   }
@@ -207,8 +208,8 @@ public class MacaroonsExamples {
         .addCaveat("authorities = ROLE_USER, DEV_TOOLS_AVAILABLE")
         .build();
 
-    new MacaroonsVerifier(macaroon)
-        .satisfyGeneral(hasAuthority("DEV_TOOLS_AVAILABLE"))
+    macaroon.verifier()
+        .satisfy(hasAuthority("DEV_TOOLS_AVAILABLE"))
         .isValid(secretKey);
     // > True
   }

--- a/src/main/java/com/github/nitram509/jmacaroons/Macaroon.java
+++ b/src/main/java/com/github/nitram509/jmacaroons/Macaroon.java
@@ -116,6 +116,10 @@ public class Macaroon implements Serializable {
     return format.serialize(this);
   }
 
+  public MacaroonsVerifier verifier() {
+    return new MacaroonsVerifier(this);
+  }
+
   /**
    * Deserializes a macaroon using the {@link MacaroonsSerializer#V1} format.
    *

--- a/src/main/java/com/github/nitram509/jmacaroons/MacaroonsVerifier.java
+++ b/src/main/java/com/github/nitram509/jmacaroons/MacaroonsVerifier.java
@@ -24,16 +24,19 @@ import java.util.List;
 import static com.github.nitram509.jmacaroons.CaveatPacket.Type;
 import static com.github.nitram509.jmacaroons.CryptoTools.*;
 import static com.github.nitram509.jmacaroons.MacaroonsConstants.*;
-import static com.github.nitram509.jmacaroons.util.ArrayTools.appendToArray;
-import static com.github.nitram509.jmacaroons.util.ArrayTools.containsElement;
 
 public class MacaroonsVerifier {
 
-  private String[] predicates = new String[0];
-  private List<Macaroon> boundMacaroons = new ArrayList<>(3);
-  private GeneralCaveatVerifier[] generalCaveatVerifiers = new GeneralCaveatVerifier[0];
+  private final List<String> predicates = new ArrayList<>();
+  private final List<Macaroon> boundMacaroons = new ArrayList<>();
+  private final List<GeneralCaveatVerifier> generalCaveatVerifiers = new ArrayList<>();
   private final Macaroon macaroon;
 
+  /**
+   * @deprecated {@link Macaroon#verifier()}
+   * @param macaroon macaroon to verify
+   */
+  @Deprecated
   public MacaroonsVerifier(Macaroon macaroon) {
     this.macaroon = macaroon;
   }
@@ -106,7 +109,7 @@ public class MacaroonsVerifier {
         if (caveat == null) continue;
         if (caveat.type == Type.cl) continue;
         if (!(caveat.type == Type.cid && caveatPackets[Math.min(i + 1, caveatPackets.length - 1)].type == Type.vid)) {
-          if (containsElement(predicates, caveat.getValueAsText()) || verifiesGeneral(caveat.getValueAsText())) {
+          if (predicates.contains(caveat.getValueAsText()) || verifiesGeneral(caveat.getValueAsText())) {
             csig = macaroon_hmac(csig, caveat.rawValue);
           }
         } else {
@@ -176,6 +179,16 @@ public class MacaroonsVerifier {
   }
 
   /**
+   * @deprecated {@link #satisfy(String)}
+   * @param caveat caveat
+   * @return this {@link com.github.nitram509.jmacaroons.MacaroonsVerifier}
+   */
+  @Deprecated
+  public MacaroonsVerifier satisfyExact(String caveat) {
+    return satisfy(caveat);
+  }
+
+  /**
    * Caveats like these are called "exact caveats" because there is exactly one way
    * to satisfy them.  Either the given caveat matches, or it doesn't.  At
    * verification time, the verifier will check each caveat in the macaroon against
@@ -186,11 +199,21 @@ public class MacaroonsVerifier {
    * @param caveat caveat
    * @return this {@link com.github.nitram509.jmacaroons.MacaroonsVerifier}
    */
-  public MacaroonsVerifier satisfyExact(String caveat) {
+  public MacaroonsVerifier satisfy(String caveat) {
     if (caveat != null) {
-      this.predicates = appendToArray(this.predicates, caveat);
+      this.predicates.add(caveat);
     }
     return this;
+  }
+
+  /**
+   * @deprecated {@link #satisfy(Macaroon)}
+   * @param preparedMacaroon preparedMacaroon
+   * @return this {@link com.github.nitram509.jmacaroons.MacaroonsVerifier}
+   */
+  @Deprecated
+  public MacaroonsVerifier satisfy3rdParty(Macaroon preparedMacaroon) {
+    return satisfy(preparedMacaroon);
   }
 
   /**
@@ -199,11 +222,21 @@ public class MacaroonsVerifier {
    * @param preparedMacaroon preparedMacaroon
    * @return this {@link com.github.nitram509.jmacaroons.MacaroonsVerifier}
    */
-  public MacaroonsVerifier satisfy3rdParty(Macaroon preparedMacaroon) {
+  public MacaroonsVerifier satisfy(Macaroon preparedMacaroon) {
     if (preparedMacaroon != null) {
       this.boundMacaroons.add(preparedMacaroon);
     }
     return this;
+  }
+
+  /**
+   * @deprecated use {@link #satisfy(GeneralCaveatVerifier)}
+   * @param verifier verifier
+   * @return this {@link com.github.nitram509.jmacaroons.MacaroonsVerifier}
+   */
+  @Deprecated
+  public MacaroonsVerifier satisfyGeneral(GeneralCaveatVerifier verifier) {
+    return satisfy(verifier);
   }
 
   /**
@@ -219,13 +252,14 @@ public class MacaroonsVerifier {
    * @param verifier verifier
    * @return this {@link com.github.nitram509.jmacaroons.MacaroonsVerifier}
    */
-  public MacaroonsVerifier satisfyGeneral(GeneralCaveatVerifier verifier) {
+  public MacaroonsVerifier satisfy(GeneralCaveatVerifier verifier) {
     if (verifier != null) {
-      this.generalCaveatVerifiers = appendToArray(this.generalCaveatVerifiers, verifier);
+      this.generalCaveatVerifiers.add(verifier);
     }
     return this;
   }
 
+  @Deprecated
   public Macaroon getMacaroon() {
     return macaroon;
   }

--- a/src/main/java/com/github/nitram509/jmacaroons/util/ArrayTools.java
+++ b/src/main/java/com/github/nitram509/jmacaroons/util/ArrayTools.java
@@ -31,31 +31,6 @@ public class ArrayTools {
     return tmp;
   }
 
-  public static String[] appendToArray(String[] elements, String newElement) {
-    assert newElement != null;
-    String[] tmp = new String[elements.length + 1];
-    System.arraycopy(elements, 0, tmp, 0, elements.length);
-    tmp[elements.length] = newElement;
-    return tmp;
-  }
-
-  public static GeneralCaveatVerifier[] appendToArray(GeneralCaveatVerifier[] elements, GeneralCaveatVerifier newElement) {
-    assert newElement != null;
-    GeneralCaveatVerifier[] tmp = new GeneralCaveatVerifier[elements.length + 1];
-    System.arraycopy(elements, 0, tmp, 0, elements.length);
-    tmp[elements.length] = newElement;
-    return tmp;
-  }
-
-  public static boolean containsElement(String[] elements, String anElement) {
-    if (elements != null) {
-      for (String element : elements) {
-        if (element.equals(anElement)) return true;
-      }
-    }
-    return false;
-  }
-
   public static byte[] flattenByteArray(List<byte[]> packets) {
     int size = 0;
     for (byte[] packet : packets) {

--- a/src/main/java/com/github/nitram509/jmacaroons/verifier/TimestampCaveatVerifier.java
+++ b/src/main/java/com/github/nitram509/jmacaroons/verifier/TimestampCaveatVerifier.java
@@ -63,8 +63,8 @@ import java.util.Date;
  * Macaroon m = new Macaroon.builder("location", "secret", "identifiert")
  *    .addCaveat("time &lt; 2042-09-23T17:42:35")
  *    .build();
- * new MacaroonsVerifier(m)
- *    .satisfyGeneral(new TimestampCaveatVerifier())
+ * m.verifier()
+ *    .satisfy(new TimestampCaveatVerifier())
  *    .assertIsValid("secret");
  * }</pre>
  */

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsPrepareRequestAndVerifyComplexTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsPrepareRequestAndVerifyComplexTest.java
@@ -77,11 +77,11 @@ public class MacaroonsPrepareRequestAndVerifyComplexTest {
 
   @Test(dependsOnMethods = "preparing_a_macaroon_for_request")
   public void verifying_valid() {
-    boolean valid = new MacaroonsVerifier(M)
-        .satisfyExact("account = 3735928559")
-        .satisfyExact("role = admin")
-        .satisfyGeneral(new TimestampCaveatVerifier())
-        .satisfy3rdParty(DP)
+    boolean valid = M.verifier()
+        .satisfy("account = 3735928559")
+        .satisfy("role = admin")
+        .satisfy(new TimestampCaveatVerifier())
+        .satisfy(DP)
         .isValid(secret);
 
     assertThat(valid).isTrue();
@@ -89,11 +89,11 @@ public class MacaroonsPrepareRequestAndVerifyComplexTest {
 
   @Test(dependsOnMethods = "preparing_a_macaroon_for_request")
   public void verifying_unprepared_macaroon__has_to_fail() {
-    boolean valid = new MacaroonsVerifier(M)
-        .satisfyExact("account = 3735928559")
-        .satisfyExact("role = admin")
-        .satisfyGeneral(new TimestampCaveatVerifier())
-        .satisfy3rdParty(D)
+    boolean valid = M.verifier()
+        .satisfy("account = 3735928559")
+        .satisfy("role = admin")
+        .satisfy(new TimestampCaveatVerifier())
+        .satisfy(D)
         .isValid(secret);
 
     assertThat(valid).isFalse();
@@ -101,10 +101,10 @@ public class MacaroonsPrepareRequestAndVerifyComplexTest {
 
   @Test(dependsOnMethods = "preparing_a_macaroon_for_request")
   public void verifying_macaroon_without_satisfying_3rd_party__has_to_fail() {
-    boolean valid = new MacaroonsVerifier(M)
-        .satisfyExact("account = 3735928559")
-        .satisfyExact("role = admin")
-        .satisfyGeneral(new TimestampCaveatVerifier())
+    boolean valid = M.verifier()
+        .satisfy("account = 3735928559")
+        .satisfy("role = admin")
+        .satisfy(new TimestampCaveatVerifier())
         .isValid(secret);
 
     assertThat(valid).isFalse();

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsPrepareRequestAndVerifyTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsPrepareRequestAndVerifyTest.java
@@ -83,10 +83,10 @@ public class MacaroonsPrepareRequestAndVerifyTest {
 
   @Test(dependsOnMethods = "preparing_a_macaroon_for_request")
   public void verifying_valid() {
-    boolean valid = new MacaroonsVerifier(M)
-        .satisfyExact("account = 3735928559")
-        .satisfyGeneral(new TimestampCaveatVerifier())
-        .satisfy3rdParty(DP)
+    boolean valid = M.verifier()
+        .satisfy("account = 3735928559")
+        .satisfy(new TimestampCaveatVerifier())
+        .satisfy(DP)
         .isValid(secret);
 
     assertThat(valid).isTrue();
@@ -94,10 +94,10 @@ public class MacaroonsPrepareRequestAndVerifyTest {
 
   @Test(dependsOnMethods = "preparing_a_macaroon_for_request")
   public void verifying_unprepared_macaroon__has_to_fail() {
-    boolean valid = new MacaroonsVerifier(M)
-        .satisfyExact("account = 3735928559")
-        .satisfyGeneral(new TimestampCaveatVerifier())
-        .satisfy3rdParty(D)
+    boolean valid = M.verifier()
+        .satisfy("account = 3735928559")
+        .satisfy(new TimestampCaveatVerifier())
+        .satisfy(D)
         .isValid(secret);
 
     assertThat(valid).isFalse();
@@ -105,9 +105,9 @@ public class MacaroonsPrepareRequestAndVerifyTest {
 
   @Test(dependsOnMethods = "preparing_a_macaroon_for_request")
   public void verifying_macaroon_without_satisfying_3rd_party__has_to_fail() {
-    boolean valid = new MacaroonsVerifier(M)
-        .satisfyExact("account = 3735928559")
-        .satisfyGeneral(new TimestampCaveatVerifier())
+    boolean valid = M.verifier()
+        .satisfy("account = 3735928559")
+        .satisfy(new TimestampCaveatVerifier())
         .isValid(secret);
 
     assertThat(valid).isFalse();
@@ -125,7 +125,7 @@ public class MacaroonsPrepareRequestAndVerifyTest {
         .addCaveat("authN", new String(caveat_key, StandardCharsets.ISO_8859_1), caveat_id)
         .build();
 
-    assertThat(new MacaroonsVerifier(M)
+    assertThat(M.verifier()
         .isValid(root_key))
         .describedAs("Original should not be valid without discharge macaroon")
         .isFalse();
@@ -134,7 +134,7 @@ public class MacaroonsPrepareRequestAndVerifyTest {
     Macaroon D = Macaroon.builder("authN", caveat_key, caveat_id)
         .build();
 
-    assertThat(new MacaroonsVerifier(D)
+    assertThat(D.verifier()
         .isValid(caveat_key))
         .describedAs("Discharge macaroon should be valid")
         .isTrue();
@@ -144,13 +144,13 @@ public class MacaroonsPrepareRequestAndVerifyTest {
         .prepareForRequest(D)
         .build();
 
-    assertThat(new MacaroonsVerifier(bound)
+    assertThat(bound.verifier()
         .isValid(caveat_key))
         .describedAs("Bound discharge macaroon should not be considered valid on its own")
         .isFalse();
 
-    assertThat(new MacaroonsVerifier(M)
-        .satisfy3rdParty(bound)
+    assertThat(M.verifier()
+        .satisfy(bound)
         .isValid(root_key))
         .describedAs("Original should be valid with third party caveat bound")
         .isTrue();

--- a/src/test/java/com/github/nitram509/jmacaroons/MacaroonsVerifierTest.java
+++ b/src/test/java/com/github/nitram509/jmacaroons/MacaroonsVerifierTest.java
@@ -48,7 +48,7 @@ public class MacaroonsVerifierTest {
   public void verification() {
     m = Macaroon.builder(location, secret, identifier).build();
 
-    MacaroonsVerifier verifier = new MacaroonsVerifier(m);
+    MacaroonsVerifier verifier = m.verifier();
     assertThat(verifier.isValid(secret)).isTrue();
   }
 
@@ -56,7 +56,7 @@ public class MacaroonsVerifierTest {
   public void verification_with_byteArray() {
     m = Macaroon.builder(location, secretBytes, identifier).build();
 
-    MacaroonsVerifier verifier = new MacaroonsVerifier(m);
+    MacaroonsVerifier verifier = m.verifier();
     assertThat(verifier.isValid(secretBytes)).isTrue();
   }
 
@@ -64,7 +64,7 @@ public class MacaroonsVerifierTest {
   public void verification_assertion() {
     m = Macaroon.builder(location, secret, identifier).build();
 
-    MacaroonsVerifier verifier = new MacaroonsVerifier(m);
+    MacaroonsVerifier verifier = m.verifier();
     verifier.assertIsValid("wrong secret");
 
     // expect MacaroonValidationException
@@ -76,10 +76,10 @@ public class MacaroonsVerifierTest {
         .addCaveat("account = 3735928559")
         .build();
 
-    MacaroonsVerifier verifier = new MacaroonsVerifier(m);
+    MacaroonsVerifier verifier = m.verifier();
     assertThat(verifier.isValid(secret)).isFalse();
 
-    verifier.satisfyExact("account = 3735928559");
+    verifier.satisfy("account = 3735928559");
     assertThat(verifier.isValid(secret)).isTrue();
   }
 
@@ -90,10 +90,10 @@ public class MacaroonsVerifierTest {
         .addCaveat("credit_allowed = true")
         .build();
 
-    MacaroonsVerifier verifier = new MacaroonsVerifier(m);
+    MacaroonsVerifier verifier = m.verifier();
     assertThat(verifier.isValid(secret)).isFalse();
 
-    verifier.satisfyExact("account = 3735928559");
+    verifier.satisfy("account = 3735928559");
     assertThat(verifier.isValid(secret)).isFalse();
   }
 
@@ -103,13 +103,13 @@ public class MacaroonsVerifierTest {
         .addCaveat("account = 3735928559")
         .build();
 
-    MacaroonsVerifier verifier = new MacaroonsVerifier(m);
+    MacaroonsVerifier verifier = m.verifier();
     assertThat(verifier.isValid(secret)).isFalse();
 
-    verifier.satisfyExact("account = 3735928559");
-    verifier.satisfyExact("IP = 127.0.0.1')");
-    verifier.satisfyExact("browser = Chrome')");
-    verifier.satisfyExact("action = deposit");
+    verifier.satisfy("account = 3735928559");
+    verifier.satisfy("IP = 127.0.0.1')");
+    verifier.satisfy("browser = Chrome')");
+    verifier.satisfy("action = deposit");
     assertThat(verifier.isValid(secret)).isTrue();
   }
 
@@ -119,10 +119,10 @@ public class MacaroonsVerifierTest {
         .addCaveat("time < " + createTimeStamp1WeekInFuture())
         .build();
 
-    MacaroonsVerifier verifier = new MacaroonsVerifier(m);
+    MacaroonsVerifier verifier = m.verifier();
     assertThat(verifier.isValid(secret)).isFalse();
 
-    verifier.satisfyGeneral(new TimestampCaveatVerifier());
+    verifier.satisfy(new TimestampCaveatVerifier());
     assertThat(verifier.isValid(secret)).isTrue();
   }
 


### PR DESCRIPTION
A change in a similar fashion as the builders one, but for verifiers.

```java
MacaroonsVerifier verifier = macaroon.verifier();
verifier.satisfy("account = 3735928559");
```

A more subtle change is also hiding here, by using `List` rather `Array` where there is no advantages in using Array (which is in holding primitive types).